### PR TITLE
Improve the build.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 articles/
+builds/*.phar
 projects/tests/vendor
 projects/tests/composer.lock
 projects/example/vendor

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To fine tune your analysis, you can use a configuration file in yaml. See [examp
 
 Optional: use the up-to-date security files configuration in [package/src/uptodate_data](./package/src/uptodate_data) folder.
 
-## Running the analysis
+## Usage
 
 Start the analysis by providing progpilot the path to the files and folders you would like to analyze, or your configuration file, or both.
 

--- a/README.md
+++ b/README.md
@@ -4,42 +4,69 @@
 
 [![Build Status](https://travis-ci.org/designsecurity/progpilot.svg?branch=master)](https://travis-ci.org/designsecurity/progpilot) [![Packagist](https://img.shields.io/packagist/v/designsecurity/progpilot.svg)](https://packagist.org/packages/designsecurity/progpilot) [![Packagist](https://img.shields.io/packagist/l/designsecurity/progpilot.svg)](LICENSE)
 ---
-## Standalone example
-- Download the latest phar archive in [releases](https://github.com/designsecurity/progpilot/releases) folder (or [builds](./builds/) folder for dev versions).
-- Optional : configure your analysis with [a yaml file](./projects/example_config/configuration.yml).
-- Optional : use the up-to-date security files configuration in [package/src/uptodate_data](./package/src/uptodate_data) folder.
-- Progpilot takes two optional arguments :
-  - your YAML configuration file (if not the default configuration will be used)
-  - your files and folders that have to be analysed
+
+## Installation
+
+### Option 1: use standalone phar
+
+- Download the latest phar archive from the [releases](https://github.com/designsecurity/progpilot/releases) page.
+- Place the file somewhere in your path and make it executable:
 
 ```shell
-php progpilot.phar --configuration ./configuration.yml example1.php example2.php ./folder1/ ./folder2/
+chmod +x progpilot_vX.Y.Z.phar
+sudo mv progpilot_vX.Y.Z.phar /usr/local/bin/progpilot
 ```
 
-## Library installation
-Use [getcomposer](https://getcomposer.org/) to install progpilot.  
-Your composer.json looks like this one :
-```javascript
-{
-    "name": "progpilot/example",
-    "description": "Example of use of Progpilot",
-    "require": {
-        "designsecurity/progpilot": "^0.8"
-    }
-} 
-```
-Then run composer :
+### Option 2: use composer
+
+Use [Composer](https://getcomposer.org/) to install progpilot:
+
 ```shell
-composer install
+composer require --dev designsecurity/progpilot
 ```
-Then you could try the following example.
+
+### Option 3: build phar from source code
+
+You need to have [phar-composer.phar](https://github.com/clue/phar-composer/releases) in your `$PATH` before starting the build.
+
+```shell
+git clone https://github.com/designsecurity/progpilot
+cd progpilot
+./build.sh
+```
+
+The resulting phar archive can be found in the `builds` folder.
+
+## Configuration (optional)
+
+To fine tune your analysis, you can use a configuration file in yaml. See [example configuration.yml](./projects/example_config/configuration.yml).
+
+Optional: use the up-to-date security files configuration in [package/src/uptodate_data](./package/src/uptodate_data) folder.
+
+## Running the analysis
+
+Start the analysis by providing progpilot the path to the files and folders you would like to analyze, or your configuration file, or both.
+
+If you do not provide a configuration file, the default configuration will be used.
+
+Example:
+
+```shell
+# without config file
+progpilot src/ example2.php
+# with a config file
+progpilot --configuration configuration.yml example1.php example2.php folder1/ folder2/
+```
+If you installed it with `composer`, the program will be located at `vendor/bin/progpilot`.
 
 ## Library example
-- For more informations : look at the [chapter about API explaination](./docs/API.md)
-- Use this code to analyze *source_code1.php* :
+
+It is also possible to use progpilot from your PHP code. For more information look at the [chapter about API explanation](./docs/API.md)
+
+Use this code to analyze *source_code1.php*:
+
 ```php
 <?php
-
 require_once './vendor/autoload.php';
 
 $context = new \progpilot\Context;
@@ -51,21 +78,20 @@ $analyzer->run($context);
 $results = $context->outputs->getResults();
 
 var_dump($results);
-
-?>
 ```
-- When source_code1.php contains this code :
+
+When source_code1.php contains this code :
+
 ```php
 <?php
-
 $var7 = $_GET["p"];
 $var4 = $var7;
 echo "$var4";
-
-?>	
 ```
-- The simplified [output](./docs/OUTPUT.md) will be :
-```javascript
+
+The simplified [output](./docs/OUTPUT.md) will be:
+
+```php
 array(1) {
   [0]=>
   array(11) {
@@ -88,26 +114,26 @@ array(1) {
   }
 }
 ```
-All files (composer.json, example1.php, source_code1.php) used in this example are in the [projects/example](./projects/example) folder.  
+All files (composer.json, example1.php, source_code1.php) used in this example are in the [projects/example](./projects/example) folder.
 For more examples look at this [page](./docs/EXAMPLES.md).
 
 ## Specify an analysis
-You can configure an analysis (the definitions of sinks, sources, sanitizers and validators) according to your own context.  
-You can define traditional variables like *_GET*, *_POST* or *_COOKIE* as untrusted and for example the return of the function *shell_exec()* too like in the following configuration :
-```javascript
+You can configure an analysis (the definitions of sinks, sources, sanitizers and validators) according to your own context.
+You can define traditional variables like *_GET*, *_POST* or *_COOKIE* as untrusted and for example the return of the function *shell_exec()* too, like in the following configuration:
+```json
 {
     "sources": [
         {"name": "_GET", "is_array": true, "language": "php"},
         {"name": "_POST", "is_array": true, "language": "php"},
         {"name": "_COOKIE", "is_array": true, "language": "php"},
         {"name": "shell_exec", "is_function": true, "language": "php"}
-		]
+    ]
 }
 ```
-See more available options in the [corresponding chapter about specifying an analysis](./docs/SPECIFY_ANALYSIS.md)
+See available options in the [corresponding chapter about specifying an analysis](./docs/SPECIFY_ANALYSIS.md).
 
 ## Development
-[Learn more](./docs/DEV.md) about the development of Progpilot
+[Learn more](./docs/DEV.md) about the development of Progpilot.
 
 ## Faq
 [Here](./docs/FAQ.md)

--- a/build.sh
+++ b/build.sh
@@ -29,4 +29,5 @@ cp -R ../../package/* ./vendor/progpilot/package
 
 echo "Generating phar..."
 php -d phar.readonly=off "$(command -v phar-composer.phar)" build .
+chmod -v +x ./build.phar
 mv -v ./build.phar ../../builds/"${newfile}".phar

--- a/build.sh
+++ b/build.sh
@@ -1,40 +1,32 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-composertool=/home/eric/dev/phar-composer.phar
-version="dev"
-date=`date "+%Y%m%d-%H%M%S"`
-newfile="progpilot_${version}${date}"
-    
-echo "Progpilot builder"
-echo "Have you updated the version of progpilot in Console/Application.php file ? (optional)"
-
-if [ -e ${composertool} ] 
-then
-    cd ./projects/phar
-    rm composer.lock
-    rm -rf ./vendor/
-    composer install
-
-    rm -rf ./vendor/progpilot/
-    mkdir ./vendor/progpilot/
-    mkdir ./vendor/progpilot/package
-    cp -R ../../package/* ./vendor/progpilot/package
-
-    rm -rf ../../builds/*
-        
-    echo "generating phar"
-
-    php -d phar.readonly=off ${composertool} build .
-    mv ./build.phar ../../builds/${newfile}.phar
-
-    rm composer.lock
-    rm -rf ./vendor/
-else
-
-echo ""
-echo "Error : ${composertool} doesn't exist"
-echo "download the latest release of phar composer tool : https://github.com/clue/phar-composer/releases"
-echo "and define the path of the tool in the composertool variable of this script"
-
+# Check if phar-composer.phar is in the $PATH
+if ! [ -x "$(command -v phar-composer.phar)" ]; then
+    echo "Error: phar-composer.phar command could not be found!"
+    echo "Make sure to download the latest release of phar composer tool: https://github.com/clue/phar-composer/releases"
+    echo "Make it executable and add it in a folder in your PATH"
+    exit 1
 fi
 
+version="dev"
+date=$(date "+%Y%m%d-%H%M%S")
+newfile="progpilot_${version}${date}"
+
+echo "Progpilot builder"
+echo "Did you update the version of progpilot in Console/Application.php file? (optional)"
+
+cd ./projects/phar || exit 1
+
+# Cleanup
+rm -f composer.lock
+rm -rf ./vendor/
+rm -rf ../../builds/*
+
+composer install
+rm -rf ./vendor/progpilot/
+mkdir -p ./vendor/progpilot/package
+cp -R ../../package/* ./vendor/progpilot/package
+
+echo "Generating phar..."
+php -d phar.readonly=off "$(command -v phar-composer.phar)" build .
+mv -v ./build.phar ../../builds/"${newfile}".phar


### PR DESCRIPTION
* User /usr/bin/env instead of hardcoded path for bash
* Check if command is in $PATH instead of hardcoding it in the script
* Exit early if the command is not found
* Use modern $() syntax instead of backticks
* Group the cleanup commands together
* Merge the mkdir commands in one with -p flag
* Add -f to rm composer.lock command so it doesn't complain if file is
  not here
* Script is now passing shellcheck with no errors
* Add verbose flag to final move
* Add phar builds to .gitignore