### PR TITLE
Remove PHP 7.4 from Unit Tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
           - "8.0"
           - "8.1"
           - "8.2"


### PR DESCRIPTION
Removes PHP 7.4 from Unit Tests are it's no longer a supported PHP version